### PR TITLE
provide verbose printing in swagger api_client behind an env vaar

### DIFF
--- a/gsi/fvs/swagger_client/api_client.py
+++ b/gsi/fvs/swagger_client/api_client.py
@@ -144,10 +144,10 @@ class ApiClient(object):
         # request url
         url = self.configuration.host + resource_path
 
-
-        print("CALL API", "method=", method, "url=", url, "qp=", query_params, 
-            "headers", header_params, "post_params", post_params,
-            "body", body, "preload", _preload_content)
+        if os.getenv("GEMINI_SWAGGER_VERBOSE"):
+            print("CALL API", "method=", method, "url=", url, "qp=", query_params, 
+                "headers", header_params, "post_params", post_params,
+                "body", body, "preload", _preload_content)
 
         # perform request and return response
         response_data = self.request(


### PR DESCRIPTION
### What's being changed:

* I added some default verbose printing in the auto-generated swagger library used by gemini_fvs.py
* It's useful but the change in this branch makes sure it's enabled via an env var
